### PR TITLE
feature/105 fixed bug where lengthy biography cannot be saved to database

### DIFF
--- a/backend/src/main/java/com/soen341/instagram/model/Account.java
+++ b/backend/src/main/java/com/soen341/instagram/model/Account.java
@@ -31,10 +31,11 @@ public class Account {
     @Temporal(TemporalType.DATE)
     @NotNull
     private Date created;
-
+    
+    @Column(columnDefinition="text")
     private String biography;
     
-   @NotNull
+    @NotNull
     private String displayName;
 
     @ManyToMany(fetch = FetchType.LAZY)   


### PR DESCRIPTION
resolves #105 

I added a extra properties to the biography field such that it allows for lengthy string. Previously, whenever the string was too lengthy, it threw an exception. 

Don't forget to update database when this is merged